### PR TITLE
UI modified for DIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [ ] 管理画面認証（EntraID）
 - [ ] 管理画面UI設計
 - [ ] 管理項目の確定
-- [ ] クライアント側アクション実行
+- [x] クライアント側アクション実行
 - [ ] サーバ側のデータ管理
 - [ ] 性能測定
 
@@ -101,10 +101,12 @@ graph TB
 
 | 項番 | 操作 | Command | CommandOption |
 |------|------|---------|-----------|
-| 1 | ロボット停止 | stop | ROS |
-| 2 | ロボット再起動 | restart | ROS |
-| 3 | プロセスA再起動 | restart | ProcessA |
-| 4 | debug | debug | "test message" |
+| 1 | ROS起動 | ros-start |  |
+| 2 | ROS停止 | ros-stop |  |
+| 3 | システム再起動 | system-reboot |  |
+| 4 | システム電源OFF | system-poweroff |  |
+| 5 | Debug1 | debug1 |  |
+| 6 | Debug2 | debug2 |  |
 
 ### メッセージサンプル
 
@@ -132,9 +134,6 @@ sequenceDiagram
     participant Dashboard
     participant Server
     participant Robot
-
-    Dashboard->>Server: GET /connected_cabots
-    Server-->>Dashboard: List of connected robots
 
     loop Polling
         Robot->>Server: GET /poll/{client_id}
@@ -207,6 +206,8 @@ docker-compose down
   - CABOT_DASHBOARD_SESSION_TIMEOUT=1800
   - CABOT_DASHBOARD_MAX_ROBOTS=20 # Maximum number of connected robots
   - CABOT_DASHBOARD_POLL_TIMEOUT=30 # Timeout period (seconds)
+  - CABOT_DASHBOARD_DEBUG_MODE=false
+  - CABOT_DASHBOARD_ALLOWED_CABOT_IDS
 
   - ~~ WEBSITES_WEBSOCKETS_ENABLED = 1 ~~
   - https://learn.microsoft.com/ja-jp/azure/app-service/reference-app-settings?source=recommendations&tabs=kudu%2Cdotnet

--- a/cabot_dashboard_server/app/config.py
+++ b/cabot_dashboard_server/app/config.py
@@ -8,6 +8,11 @@ class Settings(BaseSettings):
     max_messages: int = 100
     polling_timeout: float = float(os.getenv("CABOT_DASHBOARD_POLL_TIMEOUT", 240))
     debug_mode: bool = os.getenv("CABOT_DASHBOARD_DEBUG_MODE", "false").lower() == "true"
+    allowed_cabot_ids: str = os.getenv('CABOT_DASHBOARD_ALLOWED_CABOT_IDS', '')
+
+    @property
+    def allowed_cabot_id_list(self) -> set:
+        return set(filter(None, self.allowed_cabot_ids.split(',')))
 
     class Config:
         env_prefix = "CABOT_DASHBOARD_"

--- a/cabot_dashboard_server/app/routers/dashboard.py
+++ b/cabot_dashboard_server/app/routers/dashboard.py
@@ -20,7 +20,6 @@ async def dashboard_page(
     session_token: str = Cookie(None),
     auth_service: AuthService = Depends(get_auth_service)
 ):
-    """Display dashboard page"""
     try:
         if not session_token or not auth_service.validate_session(session_token, timeout=3600):
             return RedirectResponse(url="/login")
@@ -32,7 +31,7 @@ async def dashboard_page(
                 "base_url": request.base_url,
                 "api_key": settings.api_key,
                 "debug_mode": settings.debug_mode,
-                "user": "user1"  # 一時的な対処
+                "user": "user1"  # TODO 一時的な対処
             }
         )
     except ValueError:
@@ -43,12 +42,9 @@ async def receive_updates(
     api_key: str = Depends(get_api_key),
     robot_manager = Depends(get_robot_state_manager)
 ):
-    """Get robot information and message updates"""
     try:
-        # robot_info = robot_manager.get_robot_info()
         connected_cabot_list = robot_manager.get_connected_cabots_list()
         return {
-            # "robots": robot_info,
             "messages": robot_manager.messages,
             "events": [],
             "cabots": connected_cabot_list
@@ -88,5 +84,4 @@ async def get_messages(
     limit: int = 100,
     robot_state_manager: RobotStateManager = Depends(get_robot_state_manager)
 ):
-    """Get message history"""
     return robot_state_manager.get_messages(limit)

--- a/cabot_dashboard_server/app/services/command_queue.py
+++ b/cabot_dashboard_server/app/services/command_queue.py
@@ -19,48 +19,36 @@ class CommandQueueManager:
             logger.info(f"Initialized queue for client {client_id}")
 
     async def add_command(self, client_id: str, command: dict) -> None:
-        """Add command to queue and fire event"""
         if client_id not in self.command_queues:
             await self.initialize_client(client_id)
-
-        # First add to queue
         await self.command_queues[client_id].put(command)
         logger.debug(f"[ADD] Added command to queue for {client_id}")
-        
-        # Set event
         self.command_events[client_id].set()
         logger.debug(f"[ADD] Event set for {client_id}")
 
     async def wait_for_update(self, client_id: str) -> Dict:
-        """Wait for command to be added (with timeout)"""
         if client_id not in self.command_queues:
             await self.initialize_client(client_id)
-
         logger.debug(f"[WAIT] Starting wait for {client_id}")
-        
-        # Clear event
         self.command_events[client_id].clear()
         logger.debug(f"[WAIT] Event cleared for {client_id}")
-
         try:
-            # Wait for event with timeout
             await asyncio.wait_for(
                 self.command_events[client_id].wait(),
                 timeout=self.POLL_TIMEOUT
             )
             logger.debug(f"[WAIT] Event received for {client_id}")
-
-            # Get command from queue
             command = await self.command_queues[client_id].get()
             logger.debug(f"[WAIT] Retrieved command for {client_id}: {command}")
             return command
-
         except asyncio.TimeoutError:
             logger.debug(f"[WAIT] Timeout for {client_id} after {self.POLL_TIMEOUT}s")
             raise
+        except Exception as e:
+            logger.error(f"Error in wait_for_update: {e}")
+            raise ConnectionError(f"Client {client_id} connection error: {e}")
 
     def remove_client(self, client_id: str) -> None:
-        """Remove client's queue and event"""
         if client_id in self.command_queues:
             del self.command_queues[client_id]
         if client_id in self.command_events:
@@ -68,7 +56,6 @@ class CommandQueueManager:
         logger.info(f"Removed client {client_id}")
 
     def _validate_command(self, command: dict) -> bool:
-        """Validate command format"""
         required_fields = {'command', 'commandOption'}
         return (
             isinstance(command, dict) and

--- a/cabot_dashboard_server/static/css/dashboard.css
+++ b/cabot_dashboard_server/static/css/dashboard.css
@@ -79,3 +79,15 @@ button:disabled {
     opacity: 0.6;
     cursor: not-allowed;
 }
+
+.logout-form {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+}
+
+.logout-button {
+    padding: 10px 20px;
+    font-size: 16px;
+    cursor: pointer;
+}

--- a/cabot_dashboard_server/static/js/dashboard.js
+++ b/cabot_dashboard_server/static/js/dashboard.js
@@ -89,11 +89,11 @@ function addMessage(message, type) {
 }
 
 function updateCabotList(cabots) {
-    cabotsDiv.innerHTML = '<h2>Connected Cabots</h2>';
+    cabotsDiv.innerHTML = '<h2>Connected AI Suitcases</h2>';
     const table = document.createElement('table');
     table.innerHTML = `
         <tr>
-            <th>Cabot ID</th>
+            <th>ID</th>
             <th>Status</th>
             <th>Actions</th>
             <th>Last Poll Time</th>

--- a/cabot_dashboard_server/templates/dashboard.html
+++ b/cabot_dashboard_server/templates/dashboard.html
@@ -8,10 +8,10 @@
 </head>
 <body>
     <div id="dashboard">
-        <h1>Cabot Dashboard</h1>
+        <!--h1>Cabot Dashboard</h1-->
         <p>Welcome, {{ user }}</p>
-        <form action="/logout" method="post">
-            <input type="submit" value="Logout">
+        <form action="/logout" method="post" class="logout-form">
+            <input type="submit" value="Logout" class="logout-button">
         </form>
 
         <div id="cabots"></div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - CABOT_DASHBOARD_MAX_ROBOTS
       - CABOT_DASHBOARD_POLL_TIMEOUT
       - CABOT_DASHBOARD_DEBUG_MODE
+      - CABOT_DASHBOARD_ALLOWED_CABOT_IDS
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
下記対応いたしました。ご確認よろしくお願いします。
※サーバインスタンス反映済みです。
https://github.com/CMU-cabot/TODO-Consortium/issues/480#issuecomment-2473747327

- 表示するIDを限定する (AIS-K24-1,AIS-ACE23-2)　→　環境変数、あるいはWebUIでコンマ区切りで指定できるようにする
    - サーバ側の環境変数で定義としてます
- Cabot Dashbordのタイトルを消す
- Logoutボタンを右に寄せる
- Connected Cabots -> Connected AI Suitcases
- Cabot ID -> ID