### PR TITLE
Itohtaka/fix expo 0402

### DIFF
--- a/cabot_dashboard_client/remote-merge-env.sh
+++ b/cabot_dashboard_client/remote-merge-env.sh
@@ -9,12 +9,14 @@ remote_env="~/cabot_ws/cabot/.env"
 original_env="/tmp/original.env"
 update_env=$1
 result_env="/tmp/result.env"
+ssh_options="-o StrictHostKeyChecking=no -i $CABOT_SSH_ID_FILE"
 options="-o StrictHostKeyChecking=no -i $CABOT_SSH_ID_FILE -p"
 if [ ! -f "$update_env" ]; then
   echo "Error: $update_env does not exist."
   exit 1
 fi
 
+ssh $ssh_options $CABOT_SSH_TARGET cp -a $remote_env $remote_env.$(date +'%Y%m%d%H%M%S')
 scp $options $CABOT_SSH_TARGET:$remote_env $original_env
 python merge-env.py $original_env $update_env $result_env
 scp $options $result_env $CABOT_SSH_TARGET:$remote_env

--- a/cabot_dashboard_server/static/css/dashboard.css
+++ b/cabot_dashboard_server/static/css/dashboard.css
@@ -43,7 +43,7 @@ body {
     padding: 4px 8px;
     font-size: 14px;
     color: #495057;
-    width: calc(33.33% - 6px);
+    width: calc(100% - 6px);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -398,7 +398,7 @@ body {
 .image-versions {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 3px;
     margin: 8px 0;
 }
 
@@ -453,12 +453,21 @@ body {
 }
 
 .version-tag {
-    background-color: #eef;
+    background-color: #eee;
 }
 
-.env-tag {
-    background-color: #fee;
+.env-key-tag {
     width: calc(50% - 6px);
+}
+
+.env-value-tag {
+    width: calc(50% - 6px);
+}
+
+.env-label-tag {
+    background-color: #fff;
+    text-align: center;
+    font-weight: bold;
 }
 
 .robot-list {

--- a/cabot_dashboard_server/static/js/dashboard.js
+++ b/cabot_dashboard_server/static/js/dashboard.js
@@ -591,8 +591,9 @@ function updateDashboard(data) {
                             <div class="accordion-body">
                                 ${Object.keys(robot.env || {}).length > 0 ? `
                                 <div class="image-versions mb-2">
+                                    <div class="version-tag env-key-tag env-label-tag">Key</div><div class="version-tag env-value-tag env-label-tag">Value</div>
                                     ${Object.entries(robot.env || {}).map(([name, tag]) =>
-                                        `<div class="version-tag env-tag">${name}=${tag}</div>`
+                                        `<div class="version-tag env-key-tag">${name}</div><div class="version-tag env-value-tag" title="${tag}">${tag}</div>`
                                     ).join('')}
                                 </div>
                                 ` : robot.connected ? `


### PR DESCRIPTION
- .envを置き換える場合には事前にバックアップ（.env.ymdhms）を作成
- Image Tagsを横３列から１列に変更
- Environment Variablesを横２列から１列に変更
- Environment VariableにKey/Value見出しを追加
- Environment Variable Valueにtitle属性を付与してマウスオーバー表示
